### PR TITLE
Cast value to string before saving to configuration

### DIFF
--- a/addons/project-settings-helpers/ProjectTools.gd
+++ b/addons/project-settings-helpers/ProjectTools.gd
@@ -14,7 +14,7 @@ static func set_setting(p_name: String, p_default_value, p_pinfo: PropertyInfo) 
 
 	ProjectSettings.add_property_info(p_pinfo.to_dict())
 	ProjectSettings.set_initial_value(p_name, p_default_value)
-	save_to_config(p_name, p_default_value)
+	save_to_config(p_name, String(p_default_value))
 
 static func set_settings_dict(settings_dict:Dictionary) -> void:
 	for property_key in settings_dict.keys():


### PR DESCRIPTION
Non-String values would give the following error
```
SCRIPT ERROR: Invalid type in function 'save_to_config' in base 'GDScript'. Cannot convert argument 2 from bool to String.
          at: set_setting (res://addons/project-settings-helpers/ProjectTools.gd:17)
```
and they would not save to addons.cfg.

See for example https://github.com/rakugoteam/Rakugo/blob/1.0/addons.cfg

With this change, all properties from SettingsList are saved.